### PR TITLE
Added inheritance, special methods. Resolves #4.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
 ^.gitignore$
 ^.travis.yml$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.Rproj.user
+*.Rproj

--- a/R/roxy_docsy.R
+++ b/R/roxy_docsy.R
@@ -66,7 +66,9 @@ CLONE_RETURN <- "Cloned object of this class."
     # Add arguments?
     
     # Throws unavoidable warning if no arguments, but we don't really care
-    los_argumentos <- suppressWarnings(names(formals(func)))
+    los_argumentos <- suppressWarnings({
+        names(formals(func))
+    })
     
     if (length(los_argumentos) > 0){
 
@@ -243,6 +245,8 @@ CLONE_RETURN <- "Cloned object of this class."
     for (thisFuncName in SPECIAL_METHODS){
         
         # if not defined, skip it
+        # clone is always defined by default, other special methods only exist if
+        # explicitly defined by the class definition
         if (!thisFuncName %in% names(aClass$public_methods)) {
             next
         }

--- a/R/roxy_docsy.R
+++ b/R/roxy_docsy.R
@@ -252,7 +252,7 @@ CLONE_RETURN <- "Cloned object of this class."
         # if the function is clone, put in standard documentation
         if (thisFuncName == "clone") {
             thisFuncDescript <- sub("~~DESCRIBE THE METHOD~~", CLONE_DESCRIBE, thisFuncDescript)
-            thisFuncDescript <- sub("~~DESCRIBE THIS PARAMETER ", CLONE_PARAM, thisFuncDescript)
+            thisFuncDescript <- sub("~~DESCRIBE THIS PARAMETER~~", CLONE_PARAM, thisFuncDescript)
             thisFuncDescript <- sub("~~WHAT DOES THIS RETURN~~", CLONE_RETURN, thisFuncDescript)
         }
                 

--- a/R/roxy_docsy.R
+++ b/R/roxy_docsy.R
@@ -1,7 +1,7 @@
 CONSTRUCTOR_METHODS <- c("new", "initialize")
 SPECIAL_METHODS <- c("clone", "print", "finalize")
 
-CLONE_DESCRIBE <- "Method for copying an object. See \\href{https://adv-r.hadley.nz/r6.html#r6-semantics}{\\emph{Advanced R}} for the intricacies of R6 reference semantics." 
+CLONE_DESCRIBE <- "Method for copying an object. See \\\\href{https://adv-r.hadley.nz/r6.html#r6-semantics}{\\emph{Advanced R}} for the intricacies of R6 reference semantics." 
 CLONE_PARAM <- "logical. Whether to recursively clone nested R6 objects."
 CLONE_RETURN <- "Cloned object of this class."
 


### PR DESCRIPTION
Changes:
- Added support for class inheritance. 
    - Will recursively search for ancestor class methods and fields.
    - Added a line that contains a link to the parent class Roxygen page
- Renamed "member" to "field". The term "members" in OOP is a super-category that contains "variables" (called "fields" in R6) and "methods". See [one reference](https://www.quora.com/What-are-the-two-types-of-class-members-used-in-object-oriented-programming-languages), but can google more.
- Added a section "Special Methods" for special R6 methods like `finalize`, `print`, and `clone`. `clone` always exists, while the other two depend on people defining them. 
- Suppressed the warning that is otherwise unavoidable when getting the formals of a method that has none. 

Resolves #4 